### PR TITLE
横長ディスプレイで表示した際のUIが崩れるバグを修正

### DIFF
--- a/src/components/timepoint/index.module.sass
+++ b/src/components/timepoint/index.module.sass
@@ -17,6 +17,8 @@
 
 .dateWrapper
     min-width: 100px
+    max-width: 300px
+    width: 100%
     position: relative
 
     @media screen and (max-width: 764px)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,17 @@
 import "./_app.sass";
 
-import type { AppProps } from 'next/app'
+import type { AppProps } from "next/app";
+import Head from "next/head";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Head>
+        <title>るりとのポートフォリオ</title>
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -39,7 +39,6 @@ class MyDocument extends Document implements CustomDocumentInterface {
     return (
       <Html lang="ja-JP">
         <Head>
-          <title>{this.title}</title>
           <meta charSet="utf-8"></meta>
           <meta name="description" content={this.description} />
           <link rel="icon" href="/images/favicon.ico" />


### PR DESCRIPTION
close #25 

## やったこと
- CSSを修正してタイトル通りの内容を実装
- titleを_document -> _appに移行(公式が推奨してたので)