### PR TITLE
制作物ページをtab navigation出来るように改修

### DIFF
--- a/src/components/card/index.module.sass
+++ b/src/components/card/index.module.sass
@@ -6,6 +6,8 @@
     text-align: left
     margin-bottom: 10px
 
+.subtitle
+    color: inherit
 /* overwrite area */
 
 .card

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -48,7 +48,7 @@ const Card: React.FC<Props> = ({
           if (link !== undefined) {
             return (
               <div>
-                <a href={link}>
+                <a href={link} tabIndex={-1}>
                   <p className={styles.content}>{link_text}</p>
                 </a>
               </div>

--- a/src/components/timepoint/index.module.sass
+++ b/src/components/timepoint/index.module.sass
@@ -5,6 +5,10 @@
 .inner
     width: 80%
     margin: auto
+    color: $black
+
+    &:focus-within
+        color: $orange
 
     @media screen and (max-width: 764px)
         width: 98%
@@ -32,6 +36,7 @@
 
 .dateTitle
     @extend .subtitle
+    color: inherit
     position: absolute
     top: 50%
     left: 50%
@@ -60,6 +65,10 @@
     border-radius: 50%
     background-color: $black
 
+    &:focus
+        background-color: $orange
+        outline: none
+
     @media screen and (max-width: 764px)
         width: 20px
         height: 20px
@@ -70,3 +79,4 @@
     width: 75%
     display: flex
     flex-direction: column
+    color: inherit

--- a/src/components/timepoint/index.tsx
+++ b/src/components/timepoint/index.tsx
@@ -26,7 +26,8 @@ const TimePoint: React.FC<Props> = ({ data }) => {
       </div>
       <div className={styles.lineBlock}>
         <p className={styles.line} />
-        <p className={styles.ellipse} />
+        {/* FIXME: tabindexを当てる場合・対話的コンテンツじゃないとダメらしいのでpタグ使うの辞めたい */}
+        <p className={styles.ellipse} tabIndex={0} />
         <p className={styles.line} />
       </div>
       <div className={styles.cardWrapper}>


### PR DESCRIPTION
close #36 

## やったこと
- 制作物ページをtab navigation出来るようにした
- 制作物ページで用いているaタグにfocusが合わないようにした

動作イメージ
![tab](https://user-images.githubusercontent.com/40134104/120746338-f0e0bc80-c539-11eb-8543-7c8208a27db8.gif)
